### PR TITLE
Improve overall functionality

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,14 @@
 
 ## Usage
 
-Open the Command Palette and type `Autoprefixer`.
+* If you are in a CSS file, open the Command Palette, and type `Autoprefixer`.
+
+  ![](https://f.cloud.github.com/assets/1223565/2284892/51b999b2-9fce-11e3-9e9d-5e6a9cb4e933.gif)
+
+* If the CSS content is inline, select it, open the Command Palette, and type
+  `Autoprefixer`.
+
+  ![](https://f.cloud.github.com/assets/1223565/2284893/51e4bd18-9fce-11e3-8b1a-282f664593e9.gif)
 
 
 ## License

--- a/test.html
+++ b/test.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<head>
+	<title>test</title>
+	<style>
+		a {
+			box-sizing: border-box;
+		}
+	</style>
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
- For non CSS files, add the ability to run the selected text through `Autoprefixer`.
- Handle errors, and instead of showing the developer tools, make Atom beep when something goes wrong.
  
  ![](https://f.cloud.github.com/assets/1223565/2282084/38f3732e-9fa8-11e3-9511-fdcfbe8610a7.gif)
## 

@sindresorhus let me know if I need to change anything.
