### PR TITLE
Fix issue with inline SCSS comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,12 +14,12 @@ async function init(editor, onSave) {
 	const selectedText = onSave ? null : editor.getSelectedText();
 	const text = selectedText || editor.getText();
 
-	const options = {
-		parser: postcssSafeParser
-	};
+	const options = {};
 
 	if (editor.getGrammar().scopeName !== 'source.css') {
 		options.syntax = postcssScss;
+	} else {
+		options.parser = postcssSafeParser
 	}
 
 	try {

--- a/index.js
+++ b/index.js
@@ -16,10 +16,10 @@ async function init(editor, onSave) {
 
 	const options = {};
 
-	if (editor.getGrammar().scopeName !== 'source.css') {
-		options.syntax = postcssScss;
+	if (editor.getGrammar().scopeName === 'source.css') {
+		options.parser = postcssSafeParser;
 	} else {
-		options.parser = postcssSafeParser
+		options.syntax = postcssScss;
 	}
 
 	try {

--- a/test.scss
+++ b/test.scss
@@ -4,3 +4,15 @@ div {
 		// Test comment
 	}
 }
+
+div {
+	&:hover {
+		// display:flex;
+		display:flex;
+	}
+
+	::placeholder {
+		// change background to red
+		background: red;
+	}
+}


### PR DESCRIPTION
This fixes #62 

## Issue

This issue is because of [postcss-safe-parse](https://github.com/postcss/postcss-safe-parser) package. It doesn't play well with the scss inline syntax.

You can try this out by going here https://npm.runkit.com/postcss-safe-parser

and past below code and click on run

```js
var safe   = require('postcss-safe-parser');
const postcss = require('postcss')

var badCss = `
::placeholder {
  // hello world
  color: gray;
}
`;

postcss().process(badCss, { parser: safe }).then(function (result) {
    console.log(result.css) //= 'a {}'
});
```

it outputs

```js
::placeholder {
  // hello world
  color: gray;helloworldcolor
}
```


## Fix

Using `postcss-safe-parser` only for css files. This PR fixes that