### PR TITLE
Add command to remove prefixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ async function init(editor, onSave, type) {
 
 	try {
 		let result;
-
 		if (type === 'prefix') {
 			result = await postcss(autoprefixer(atom.config.get('autoprefixer'))).process(text, options);
 		} else {

--- a/index.js
+++ b/index.js
@@ -14,12 +14,12 @@ async function init(editor, onSave) {
 	const selectedText = onSave ? null : editor.getSelectedText();
 	const text = selectedText || editor.getText();
 
-	const options = {
-		parser: postcssSafeParser
-	};
+	const options = {};
 
 	if (editor.getGrammar().scopeName !== 'source.css') {
 		options.syntax = postcssScss;
+	} else {
+		options.parser = postcssSafeParser
 	}
 
 	try {

--- a/index.js
+++ b/index.js
@@ -16,10 +16,10 @@ async function init(editor, onSave) {
 
 	const options = {};
 
-	if (editor.getGrammar().scopeName !== 'source.css') {
-		options.syntax = postcssScss;
+	if (editor.getGrammar().scopeName === 'source.css') {
+		options.parser = postcssSafeParser;
 	} else {
-		options.parser = postcssSafeParser
+		options.syntax = postcssScss;
 	}
 
 	try {

--- a/index.js
+++ b/index.js
@@ -4,13 +4,14 @@ import postcss from 'postcss';
 import autoprefixer from 'autoprefixer';
 import postcssSafeParser from 'postcss-safe-parser';
 import postcssScss from 'postcss-scss';
+import unprefix from 'postcss-unprefix';
 
 const SUPPORTED_SCOPES = new Set([
 	'source.css',
 	'source.css.scss'
 ]);
 
-async function init(editor, onSave) {
+async function init(editor, onSave, type) {
 	const selectedText = onSave ? null : editor.getSelectedText();
 	const text = selectedText || editor.getText();
 
@@ -23,7 +24,13 @@ async function init(editor, onSave) {
 	}
 
 	try {
-		const result = await postcss(autoprefixer(atom.config.get('autoprefixer'))).process(text, options);
+		let result;
+
+		if (type === 'prefix') {
+			result = await postcss(autoprefixer(atom.config.get('autoprefixer'))).process(text, options);
+		} else {
+			result = await postcss([ unprefix() ]).process(text, options);
+		}
 
 		result.warnings().forEach(x => {
 			console.warn(x.toString());
@@ -96,16 +103,24 @@ export function activate() {
 			const isCSS = SUPPORTED_SCOPES.has(editor.getGrammar().scopeName);
 
 			if (isCSS && atom.config.get('autoprefixer.runOnSave')) {
-				await init(editor, true);
+				await init(editor, true, 'prefix');
 			}
 		});
 	}));
 
-	this.subscriptions.add(atom.commands.add('atom-workspace', 'autoprefixer', () => {
+	this.subscriptions.add(atom.commands.add('atom-workspace', 'autoprefixer:prefix', () => {
 		const editor = atom.workspace.getActiveTextEditor();
 
 		if (editor) {
-			init(editor);
+			init(editor, false, 'prefix');
+		}
+	}));
+
+	this.subscriptions.add(atom.commands.add('atom-workspace', 'autoprefixer:remove-prefixes', () => {
+		const editor = atom.workspace.getActiveTextEditor();
+
+		if (editor) {
+			init(editor, false, 'removePrefixes');
 		}
 	}));
 }

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ async function init(editor, onSave, type) {
 		if (type === 'prefix') {
 			result = await postcss(autoprefixer(atom.config.get('autoprefixer'))).process(text, options);
 		} else {
-			result = await postcss([ unprefix() ]).process(text, options);
+			result = await postcss([unprefix()]).process(text, options);
 		}
 
 		result.warnings().forEach(x => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "autoprefixer",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "Prefix CSS and SCSS",
 	"license": "MIT",
 	"repository": "sindresorhus/atom-autoprefixer",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 		"autoprefixer": "^9.5.1",
 		"postcss": "^7.0.16",
 		"postcss-safe-parser": "^4.0.1",
-		"postcss-scss": "^2.0.0"
+		"postcss-scss": "^2.0.0",
+		"postcss-unprefix": "^2.1.4"
 	},
 	"devDependencies": {
 		"xo": "^0.24.0"
@@ -34,7 +35,8 @@
 	"activationCommands": {
 		"atom-workspace": [
 			"core:save",
-			"autoprefixer"
+			"autoprefixer:prefix",
+			"autoprefixer:remove-prefixes"
 		]
 	},
 	"xo": {

--- a/readme.md
+++ b/readme.md
@@ -14,13 +14,25 @@ Or, Settings → Install → Search for `autoprefixer`
 
 ## Usage
 
-- Open the Command Palette and type `autoprefixer`.
+### Prefix
 
-	![](https://f.cloud.github.com/assets/1223565/2284892/51b999b2-9fce-11e3-9e9d-5e6a9cb4e933.gif)
+- Open the Command Palette and type `Autoprefixer: Prefix`.
 
-- In an HTML file, select the CSS, open the Command Palette, and type `autoprefixer`.
+	![](https://user-images.githubusercontent.com/6153816/57973335-23f09b80-79c5-11e9-91cc-66ae1ce9f99d.gif)
 
-	![](https://f.cloud.github.com/assets/1223565/2284893/51e4bd18-9fce-11e3-8b1a-282f664593e9.gif)
+- In an HTML file, select the CSS, open the Command Palette, and type `Autoprefixer: Prefix`.
+
+	![](https://user-images.githubusercontent.com/6153816/57973336-23f09b80-79c5-11e9-8f21-edf4102c2adf.gif)
+
+### Remove Prefixes
+
+	- Open the Command Palette and type `Autoprefixer: Remove Prefixes`.
+
+		![](https://user-images.githubusercontent.com/6153816/57973337-23f09b80-79c5-11e9-8e68-5f48f2ea2dd1.gif)
+
+	- In an HTML file, select the CSS, open the Command Palette, and type `Autoprefixer: Remove Prefixes`.
+
+		![](https://user-images.githubusercontent.com/6153816/57973338-24893200-79c5-11e9-869a-25b7e28387f4.gif)
 
 
 ## Settings
@@ -34,7 +46,8 @@ Set the keyboard shortcut you want in your [keymap](http://flight-manual.atom.io
 
 ```cson
 'atom-text-editor':
-	'cmd-shift-x': 'autoprefixer'
+	'cmd-shift-x': 'autoprefixer:prefix'
+	'cmd-shift-u': 'autoprefixer:remove-prefixes'
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -26,13 +26,13 @@ Or, Settings → Install → Search for `autoprefixer`
 
 ### Remove Prefixes
 
-	- Open the Command Palette and type `Autoprefixer: Remove Prefixes`.
+- Open the Command Palette and type `Autoprefixer: Remove Prefixes`.
 
-		![](https://user-images.githubusercontent.com/6153816/57973337-23f09b80-79c5-11e9-8e68-5f48f2ea2dd1.gif)
+	![](https://user-images.githubusercontent.com/6153816/57973337-23f09b80-79c5-11e9-8e68-5f48f2ea2dd1.gif)
 
-	- In an HTML file, select the CSS, open the Command Palette, and type `Autoprefixer: Remove Prefixes`.
+- In an HTML file, select the CSS, open the Command Palette, and type `Autoprefixer: Remove Prefixes`.
 
-		![](https://user-images.githubusercontent.com/6153816/57973338-24893200-79c5-11e9-869a-25b7e28387f4.gif)
+	![](https://user-images.githubusercontent.com/6153816/57973338-24893200-79c5-11e9-869a-25b7e28387f4.gif)
 
 
 ## Settings

--- a/test.css
+++ b/test.css
@@ -1,3 +1,15 @@
-div {
-	display: flex;
+::-webkit-input-placeholder {
+	background: red;
+}
+::-moz-placeholder {
+	background: red;
+}
+:-ms-input-placeholder {
+	background: red;
+}
+::-ms-input-placeholder {
+	background: red;
+}
+::placeholder {
+	background: red;
 }

--- a/test.css
+++ b/test.css
@@ -1,15 +1,3 @@
-::-webkit-input-placeholder {
-	background: red;
-}
-::-moz-placeholder {
-	background: red;
-}
-:-ms-input-placeholder {
-	background: red;
-}
-::-ms-input-placeholder {
-	background: red;
-}
 ::placeholder {
 	background: red;
 }

--- a/test.html
+++ b/test.html
@@ -3,7 +3,7 @@
 	<title>test</title>
 	<style>
 		div {
-			display: flex;
+			filter: grayscale(50%);
 		}
 	</style>
 </head>

--- a/test.scss
+++ b/test.scss
@@ -4,3 +4,15 @@ div {
 		// Test comment
 	}
 }
+
+div {
+	&:hover {
+		// display:flex;
+		display:flex;
+	}
+
+	::placeholder {
+		// change background to red
+		background: red;
+	}
+}


### PR DESCRIPTION
As suggested in https://github.com/sindresorhus/atom-autoprefixer/issues/59#issuecomment-492123454

- Added new option `Autoprefix: Remove Prefixes`

- Renamed "Autoprefix" to "Autoprefix: Prefix"

- updated readme with all the examples

this should close #59 

Any thoughts to improve this PR is welcome.