### PR TITLE
Support CSS embedded in HTML files

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,11 +92,11 @@ export function activate() {
 	this.subscriptions = new CompositeDisposable();
 
 	this.subscriptions.add(atom.workspace.observeTextEditors(editor => {
-		editor.getBuffer().onWillSave(() => {
+		editor.getBuffer().onWillSave(async () => {
 			const isCSS = SUPPORTED_SCOPES.has(editor.getGrammar().scopeName);
 
 			if (isCSS && atom.config.get('autoprefixer.runOnSave')) {
-				init(editor, true);
+				await init(editor, true);
 			}
 		});
 	}));

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ async function init(editor, onSave) {
 
 	try {
 		let outCss;
-		// Package htmlPostCss requires complete html to process, selectedText doesn't work
+		// The `html-postcss` package requires complete HTML to work, so `selectedText` doesn't work
 		if (isHTML && !selectedText) {
 			const processor = new HTMLPostCSS(autoprefixer(atom.config.get('autoprefixer')));
 			outCss = processor.process(text, {}, options);

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const SUPPORTED_SCOPES = new Set([
 const HTML_SCOPE = 'text.html.basic';
 
 async function init(editor, onSave) {
-	const { scopeName } = editor.getGrammar();
+	const {scopeName} = editor.getGrammar();
 	const isHTML = scopeName === HTML_SCOPE;
 
 	const selectedText = onSave ? null : editor.getSelectedText();

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ async function init(editor, onSave) {
 		let outCss;
 		// The `html-postcss` package requires complete HTML to work, so `selectedText` doesn't work
 		if (isHTML && !selectedText) {
-			const processor = new HTMLPostCSS(autoprefixer(atom.config.get('autoprefixer')));
+			const processor = new HtmlPostCss(autoprefixer(atom.config.get('autoprefixer')));
 			outCss = processor.process(text, {}, options);
 		} else {
 			const result = await postcss(autoprefixer(atom.config.get('autoprefixer'))).process(text, options);

--- a/index.js
+++ b/index.js
@@ -14,12 +14,12 @@ async function init(editor, onSave) {
 	const selectedText = onSave ? null : editor.getSelectedText();
 	const text = selectedText || editor.getText();
 
-	const options = {
-		parser: postcssSafeParser
-	};
+	const options = {};
 
 	if (editor.getGrammar().scopeName !== 'source.css') {
 		options.syntax = postcssScss;
+	} else {
+		options.parser = postcssSafeParser
 	}
 
 	try {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import postcss from 'postcss';
 import autoprefixer from 'autoprefixer';
 import postcssSafeParser from 'postcss-safe-parser';
 import postcssScss from 'postcss-scss';
-import HTMLPostCSS from 'html-postcss';
+import HtmlPostCss from 'html-postcss';
 
 const SUPPORTED_SCOPES = new Set([
 	'source.css',

--- a/index.js
+++ b/index.js
@@ -16,10 +16,10 @@ async function init(editor, onSave) {
 
 	const options = {};
 
-	if (editor.getGrammar().scopeName !== 'source.css') {
-		options.syntax = postcssScss;
+	if (editor.getGrammar().scopeName === 'source.css') {
+		options.parser = postcssSafeParser;
 	} else {
-		options.parser = postcssSafeParser
+		options.syntax = postcssScss;
 	}
 
 	try {

--- a/index.js
+++ b/index.js
@@ -45,6 +45,9 @@ async function init(editor, onSave, type) {
 				});
 				outCss = result.css;
 			}
+		} else if (isHTML && !selectedText) {
+			const processor = new HtmlPostCss(unprefix());
+			outCss = processor.process(text, {}, options);
 		} else {
 			const result = await postcss([unprefix()]).process(text, options);
 			result.warnings().forEach(x => {

--- a/index.js
+++ b/index.js
@@ -4,8 +4,7 @@ import postcss from 'postcss';
 import autoprefixer from 'autoprefixer';
 import postcssSafeParser from 'postcss-safe-parser';
 import postcssScss from 'postcss-scss';
-import htmlPostCss from 'html-postcss';
-
+import HTMLPostCSS from 'html-postcss';
 
 const SUPPORTED_SCOPES = new Set([
 	'source.css',
@@ -15,7 +14,7 @@ const SUPPORTED_SCOPES = new Set([
 const HTML_SCOPE = 'text.html.basic';
 
 async function init(editor, onSave) {
-	const scopeName = editor.getGrammar().scopeName;
+	const { scopeName } = editor.getGrammar();
 	const isHTML = scopeName === HTML_SCOPE;
 
 	const selectedText = onSave ? null : editor.getSelectedText();
@@ -31,9 +30,9 @@ async function init(editor, onSave) {
 
 	try {
 		let outCss;
-		// htmlPostCss requires complete html to process, selectedText doesn't work
+		// Package htmlPostCss requires complete html to process, selectedText doesn't work
 		if (isHTML && !selectedText) {
-			const processor = new htmlPostCss(autoprefixer(atom.config.get('autoprefixer')));
+			const processor = new HTMLPostCSS(autoprefixer(atom.config.get('autoprefixer')));
 			outCss = processor.process(text, {}, options);
 		} else {
 			const result = await postcss(autoprefixer(atom.config.get('autoprefixer'))).process(text, options);
@@ -43,7 +42,7 @@ async function init(editor, onSave) {
 					detail: x.toString()
 				});
 			});
-			outCss = result.css
+			outCss = result.css;
 		}
 
 		const cursorPosition = editor.getCursorBufferPosition();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "autoprefixer",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "Prefix CSS and SCSS",
 	"license": "MIT",
 	"repository": "sindresorhus/atom-autoprefixer",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 	],
 	"dependencies": {
 		"autoprefixer": "^9.5.1",
+		"html-postcss": "^0.1.2",
 		"postcss": "^7.0.16",
 		"postcss-safe-parser": "^4.0.1",
 		"postcss-scss": "^2.0.0"

--- a/readme.md
+++ b/readme.md
@@ -18,9 +18,13 @@ Or, Settings → Install → Search for `autoprefixer`
 
 	![](https://f.cloud.github.com/assets/1223565/2284892/51b999b2-9fce-11e3-9e9d-5e6a9cb4e933.gif)
 
+- In an HTML file, open the Command Palette, and type `autoprefixer`.
+
+	![](https://user-images.githubusercontent.com/6153816/58272510-55de7500-7dac-11e9-9f78-9ab20aa677c4.gif)
+
 - In an HTML file, select the CSS, open the Command Palette, and type `autoprefixer`.
 
-	![](https://f.cloud.github.com/assets/1223565/2284893/51e4bd18-9fce-11e3-8b1a-282f664593e9.gif)
+	![](https://user-images.githubusercontent.com/6153816/58272511-55de7500-7dac-11e9-9e97-a99393568594.gif)
 
 
 ## Settings

--- a/test.css
+++ b/test.css
@@ -1,3 +1,7 @@
 div {
-	display: flex;
+	filter: grayscale(50%);
+}
+
+div {
+	transform: rotate(180deg);
 }

--- a/test.html
+++ b/test.html
@@ -2,17 +2,16 @@
 <head>
 	<title>test</title>
 	<style>
-		div {
-			 filter: grayscale(50%);
+		::placeholder {
+			background: red;
 		}
 	</style>
 	<style>
 		div {
-			transform: rotate(180deg);
+			filter: grayscale(50%);
 		}
 	</style>
 </head>
 <body>
 
 </body>
-</html>

--- a/test.html
+++ b/test.html
@@ -3,7 +3,13 @@
 	<title>test</title>
 	<style>
 		div {
-			display: flex;
+			filter: grayscale(50%);
+		}
+	</style>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<style>
+		div {
+			transform: rotate(180deg);
 		}
 	</style>
 </head>

--- a/test.scss
+++ b/test.scss
@@ -4,3 +4,15 @@ div {
 		// Test comment
 	}
 }
+
+div {
+	&:hover {
+		// display:flex;
+		display:flex;
+	}
+
+	::placeholder {
+		// change background to red
+		background: red;
+	}
+}


### PR DESCRIPTION
This should close #3

## Issue

Right now, if you want to autoprefix css inside html file, you need to select the css part of the file and then select `autoprefixer` command.

## Fix

As mentioned in [this comment](https://github.com/sindresorhus/atom-autoprefixer/issues/3#issue-28458112), using [RebelMail/html-postcss](https://github.com/RebelMail/html-postcss) package, we are able to detect css scope inside html and pass it to postcss.

Note: [RebelMail/html-postcss](https://github.com/RebelMail/html-postcss) package needs complete HTML to work, so if user selected part of css inside html file we're rolling back to using old process.

